### PR TITLE
protojson: add UseHexForBytes option

### DIFF
--- a/encoding/protojson/encode.go
+++ b/encoding/protojson/encode.go
@@ -6,6 +6,7 @@ package protojson
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 
 	"google.golang.org/protobuf/internal/encoding/json"
@@ -80,6 +81,10 @@ type MarshalOptions struct {
 	//  ║ {}    │ map fields                 ║
 	//  ╚═══════╧════════════════════════════╝
 	EmitUnpopulated bool
+
+	// If UseHexForBytes is set, bytes fields are marshaled as hex strings
+	// instead of base64.
+	UseHexForBytes bool
 
 	// Resolver is used for looking up types when expanding google.protobuf.Any
 	// messages. If nil, this defaults to using protoregistry.GlobalTypes.
@@ -285,7 +290,13 @@ func (e encoder) marshalSingular(val protoreflect.Value, fd protoreflect.FieldDe
 		e.WriteFloat(val.Float(), 64)
 
 	case protoreflect.BytesKind:
-		e.WriteString(base64.StdEncoding.EncodeToString(val.Bytes()))
+		var encoded string
+		if e.opts.UseHexForBytes {
+			encoded = hex.EncodeToString(val.Bytes())
+		} else {
+			encoded = base64.StdEncoding.EncodeToString(val.Bytes())
+		}
+		e.WriteString(encoded)
 
 	case protoreflect.EnumKind:
 		if fd.Enum().FullName() == genid.NullValue_enum_fullname {


### PR DESCRIPTION
Adds the option `UseHexForBytes` to the `protojson` encode and decode options.