### PR TITLE
protojson: add UseHexForBytes option

### DIFF
--- a/encoding/protojson/decode.go
+++ b/encoding/protojson/decode.go
@@ -6,6 +6,7 @@ package protojson
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"strconv"
@@ -40,6 +41,10 @@ type UnmarshalOptions struct {
 
 	// If DiscardUnknown is set, unknown fields and enum name values are ignored.
 	DiscardUnknown bool
+
+	// If UseHexForBytes is set, bytes fields are un-marshaled as hex
+	// strings instead of base64.
+	UseHexForBytes bool
 
 	// Resolver is used for looking up types when unmarshaling
 	// google.protobuf.Any messages or extension fields.
@@ -333,8 +338,14 @@ func (d decoder) unmarshalScalar(fd protoreflect.FieldDescriptor) (protoreflect.
 		}
 
 	case protoreflect.BytesKind:
-		if v, ok := unmarshalBytes(tok); ok {
-			return v, nil
+		if d.opts.UseHexForBytes {
+			if v, ok := unmarshalBytesFromHex(tok); ok {
+				return v, nil
+			}
+		} else {
+			if v, ok := unmarshalBytes(tok); ok {
+				return v, nil
+			}
 		}
 
 	case protoreflect.EnumKind:
@@ -477,6 +488,19 @@ func unmarshalBytes(tok json.Token) (protoreflect.Value, bool) {
 		enc = enc.WithPadding(base64.NoPadding)
 	}
 	b, err := enc.DecodeString(s)
+	if err != nil {
+		return protoreflect.Value{}, false
+	}
+	return protoreflect.ValueOfBytes(b), true
+}
+
+func unmarshalBytesFromHex(tok json.Token) (protoreflect.Value, bool) {
+	if tok.Kind() != json.String {
+		return protoreflect.Value{}, false
+	}
+
+	s := tok.ParsedString()
+	b, err := hex.DecodeString(s)
 	if err != nil {
 		return protoreflect.Value{}, false
 	}

--- a/encoding/protojson/encode.go
+++ b/encoding/protojson/encode.go
@@ -6,6 +6,7 @@ package protojson
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 
 	"google.golang.org/protobuf/internal/encoding/json"
@@ -101,6 +102,10 @@ type MarshalOptions struct {
 	// EmitUnpopulated takes precedence over EmitDefaultValues since the former generates
 	// a strict superset of the latter.
 	EmitDefaultValues bool
+
+	// If UseHexForBytes is set, bytes fields are marshaled as hex strings
+	// instead of base64.
+	UseHexForBytes bool
 
 	// Resolver is used for looking up types when expanding google.protobuf.Any
 	// messages. If nil, this defaults to using protoregistry.GlobalTypes.
@@ -322,7 +327,13 @@ func (e encoder) marshalSingular(val protoreflect.Value, fd protoreflect.FieldDe
 		e.WriteFloat(val.Float(), 64)
 
 	case protoreflect.BytesKind:
-		e.WriteString(base64.StdEncoding.EncodeToString(val.Bytes()))
+		var encoded string
+		if e.opts.UseHexForBytes {
+			encoded = hex.EncodeToString(val.Bytes())
+		} else {
+			encoded = base64.StdEncoding.EncodeToString(val.Bytes())
+		}
+		e.WriteString(encoded)
 
 	case protoreflect.EnumKind:
 		if fd.Enum().FullName() == genid.NullValue_enum_fullname {


### PR DESCRIPTION
This PR adds the changes from https://github.com/lightninglabs/protobuf-go-hex-display/pull/3 to a new 1-36-11 base branch which is tracking upstream/v1.36.11.